### PR TITLE
Remove empty function on variable function

### DIFF
--- a/app/core/gui.class.php
+++ b/app/core/gui.class.php
@@ -71,12 +71,12 @@ class Core_GUI
 			// Sets the module options
 			if ( !empty($bgp_module::$module_definition['module_options']) ) {
 
-				if ( !empty($bgp_module::getModuleOption( 'empty_navbar' )) ) {
+				if ( $bgp_module::getModuleOption( 'empty_navbar' ) != null ) {
 
 					$this->empty_navbar = boolval( $bgp_module::getModuleOption( 'empty_navbar' ) );
 				}
 
-				if ( !empty($bgp_module::getModuleOption( 'no_sidebar' )) ) {
+				if ( $bgp_module::getModuleOption( 'no_sidebar' ) != null ) {
 
 					$this->no_sidebar = boolval( $bgp_module::getModuleOption( 'no_sidebar' ) );
 				}


### PR DESCRIPTION
I'm getting "Fatal error: Can't use function return value in write context in app/core/gui.class.php on line 74"

``` php

if ( !empty($bgp_module::$module_definition['module_options']) ) {

                if ( !empty($bgp_module::getModuleOption( 'empty_navbar' )) ) {

                    $this->empty_navbar = boolval( $bgp_module::getModuleOption( 'empty_navbar' ) );
                }

                if ( !empty($bgp_module::getModuleOption( 'no_sidebar' )) ) {

                    $this->no_sidebar = boolval( $bgp_module::getModuleOption( 'no_sidebar' ) );
                }
            }
```

This is most likely thrown from using empty on a variable function.

I have removed !empty and replaced it with != null.
